### PR TITLE
Handle websocket internal errors

### DIFF
--- a/rocketchat-in.js
+++ b/rocketchat-in.js
@@ -149,6 +149,11 @@ module.exports = function(RED) {
 					ws.terminate();
 					setTimeout(startListening, 10000);
 				});
+
+				// Safelly handle ws errors so it doesn't break the application
+				// Will forward internal errors to catch
+				ws.onerror = () => {};
+
 				ws.on('message', data => {
 					const { id, msg, error, fields } = EJSON.parse(data);
 


### PR DESCRIPTION
Previously WebSocket internal errors, such as `ENOTFOUND`, would go as an unhandled error breaking the node-red application. 
Passing and `onerror` function will fix this and forward the error to the catch block.